### PR TITLE
Separate installation and starting of headless client

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN	sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
 	update-locale LANG=en_GB.UTF-8 && \
 	rm -rf /var/lib/{apt,dpkg,cache}
 
-ENV	LANG en_GB.UTF-8 
+ENV	LANG en_GB.UTF-8
 
 # Fix the LetsEncrypt CA cert
 RUN	sed -i 's#mozilla/DST_Root_CA_X3.crt#!mozilla/DST_Root_CA_X3.crt#' /etc/ca-certificates.conf && update-ca-certificates
@@ -49,10 +49,10 @@ RUN	addgroup -gid ${USER} steam && \
 	curl -sqL ${STEAMCMDURL} | tar zxfv - && \
 	chown -R ${USER}:${USER} ${STEAMCMDDIR} ${HOMEDIR} ${STEAMAPPDIR} /Config /Logs
 
-COPY	./start_neosvr.sh /Scripts/
+COPY	./setup_neosvr.sh ./start_neosvr.sh /Scripts/
 
-RUN	chown -R ${USER}:${USER} /Scripts/start_neosvr.sh && \
-	chmod +x /Scripts/start_neosvr.sh
+RUN	chown -R ${USER}:${USER} /Scripts/setup_neosvr.sh /Scripts/start_neosvr.sh && \
+	chmod +x /Scripts/setup_neosvr.sh /Scripts/start_neosvr.sh
 
 # Switch to user
 USER ${USER}
@@ -61,4 +61,4 @@ WORKDIR ${STEAMAPPDIR}
 
 VOLUME ["${STEAMAPPDIR}", "/Config", "/Logs"]
 
-CMD ["bash", "/Scripts/start_neosvr.sh"]
+CMD /Scripts/setup_neosvr.sh && /Scripts/start_neosvr.sh

--- a/setup_neosvr.sh
+++ b/setup_neosvr.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+bash "${STEAMCMDDIR}/steamcmd.sh" \
+	+force_install_dir ${STEAMAPPDIR} \
+	+login ${STEAMLOGIN} \
+	+app_license_request ${STEAMAPPID} \
+	+app_update ${STEAMAPPID} -beta ${STEAMBETA} -betapassword ${STEAMBETAPASSWORD} validate \
+	+quit
+find ${STEAMAPPDIR}/Data/Assets -type f -atime +7 -delete
+find ${STEAMAPPDIR}/Data/Cache -type f -atime +7 -delete
+find /Logs -type f -name *.log -atime +30 -delete

--- a/start_neosvr.sh
+++ b/start_neosvr.sh
@@ -1,12 +1,3 @@
 #!/bin/sh
 
-bash "${STEAMCMDDIR}/steamcmd.sh" \
-	+force_install_dir ${STEAMAPPDIR} \
-	+login ${STEAMLOGIN} \
-	+app_license_request ${STEAMAPPID} \
-	+app_update ${STEAMAPPID} -beta ${STEAMBETA} -betapassword ${STEAMBETAPASSWORD} validate \
-	+quit
-find ${STEAMAPPDIR}/Data/Assets -type f -atime +7 -delete
-find ${STEAMAPPDIR}/Data/Cache -type f -atime +7 -delete
-find /Logs -type f -name *.log -atime +30 -delete
 mono ${STEAMAPPDIR}/Neos.exe -c /Config/Config.json -l /Logs


### PR DESCRIPTION
This pull request splits the `start_neosvr.sh` script into two scripts: One that does the installation of the headless client (`setup_neosvr.sh`) and one that actually runs it (the remainder of `start_neosvr.sh`). I've modified the `Dockerfile` to run these scripts in succession so the behavior of the image does not change.

The benefit to this is that Docker images based on this one will be able to run a different application instead of launching the headless client immediately, while maintaining the ability to grab the latest headless client at runtime. This could be used to launch a wrapper around the headless client instead of the headless client itself, for example.

Images built from this one would just need to call `setup_neosvr.sh` in their command and then put their custom commands before or in place of `start_neosvr.sh`.