### PR TITLE
Enable graceful shutdown of headless client

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,4 +61,7 @@ WORKDIR ${STEAMAPPDIR}
 
 VOLUME ["${STEAMAPPDIR}", "/Config", "/Logs"]
 
-CMD /Scripts/setup_neosvr.sh && /Scripts/start_neosvr.sh
+STOPSIGNAL SIGINT
+
+ENTRYPOINT ["/Scripts/setup_neosvr.sh"]
+CMD ["/Scripts/start_neosvr.sh"]

--- a/setup_neosvr.sh
+++ b/setup_neosvr.sh
@@ -9,3 +9,4 @@ bash "${STEAMCMDDIR}/steamcmd.sh" \
 find ${STEAMAPPDIR}/Data/Assets -type f -atime +7 -delete
 find ${STEAMAPPDIR}/Data/Cache -type f -atime +7 -delete
 find /Logs -type f -name *.log -atime +30 -delete
+exec $*

--- a/start_neosvr.sh
+++ b/start_neosvr.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-mono ${STEAMAPPDIR}/Neos.exe -c /Config/Config.json -l /Logs
+exec mono ${STEAMAPPDIR}/Neos.exe -c /Config/Config.json -l /Logs


### PR DESCRIPTION
Currently, the headless client cannot receive the terminate signal inside the container (when using `docker stop` for example) because it is not running as PID 1. This can be shown with `ps` (after installing `procps` in the container):

```
# docker exec neosvr-headless ps a
    PID TTY      STAT   TIME COMMAND
      1 pts/0    Ss+    0:00 /bin/sh -c /Scripts/setup_neosvr.sh && /Scripts/start_neosvr.sh
    102 pts/0    S+     0:00 /bin/sh /Scripts/start_neosvr.sh
    103 pts/0    Sl+    0:18 mono /home/steam/neosvr-headless/Neos.exe -c /Config/Config.json -l /Logs
```

PID 1 is taken by the script that launched the headless client. This pull request resolves this issue by utilizing `exec` statements in the scripts to make `mono` replace the shell process and inherit its PID:

```
# docker exec neosvr-headless ps a
    PID TTY      STAT   TIME COMMAND
      1 pts/0    Ssl+   0:11 mono /home/steam/neosvr-headless/Neos.exe -c /Config/Config.json -l /Logs
```

This PR also changes the stop signal from the default `SIGTERM` to `SIGINT`, because the headless client does not seem to respond to `SIGTERM` even as PID 1. `SIGINT` emulates a press of `Ctrl+C` at the console. In my testing, this made the headless client shut down but not exit its process, meaning Docker still ultimately kills the container with `SIGKILL`.  But at least this allows the headless client to perform a clean shutdown before that happens.

I've also made improvements to my previous PR (#1) by making the following changes:

- The script `setup_neosvr.sh` has been relegated to being an `ENTRYPOINT`. This means that child images based on this one no longer need to include `setup_neosvr.sh` in their `CMD` if they choose to override it.
- At the end of `setup_neosvr.sh`, any arguments passed (e.g. `CMD`) are executed verbatim.
  - By default, this is `start_neosvr.sh`.
- Any custom commands executed also get the benefit of being PID 1 so they will be terminated properly if the Docker container is stopped.

tl;dr: These changes allow `CMD` to be overridden without any "gotchas" and get the expected behavior, while maintaining the benefit that the headless client is downloaded at runtime.