### PR TITLE
Consistently use newer ENV syntax

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN	apt-get update && \
 	update-locale LANG=en_US.UTF-8 && \
 	update-locale LANG=en_GB.UTF-8 && \
 	rm -rf /var/lib/{apt,dpkg,cache}
-ENV	LANG en_GB.UTF-8
+ENV	LANG=en_GB.UTF-8
 
 # Fix the LetsEncrypt CA cert (is this still needed?)
 #RUN	sed -i 's#mozilla/DST_Root_CA_X3.crt#!mozilla/DST_Root_CA_X3.crt#' /etc/ca-certificates.conf && update-ca-certificates


### PR DESCRIPTION
There was an envar that was using the legacy syntax, which was inconsistent with other uses of ENV in the file, and will throw an error on newer versions of docker