### PR TITLE
fix(steamcmd): Force platform for updating Resonite

### DIFF
--- a/src/setup_resonite.sh
+++ b/src/setup_resonite.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 bash "${STEAMCMDDIR}/steamcmd.sh" \
+	+@sSteamCmdForcePlatformType windows \
 	+force_install_dir ${STEAMAPPDIR} \
 	+login ${STEAMLOGIN} \
 	+app_license_request ${STEAMAPPID} \


### PR DESCRIPTION
As of the release of the splittening, trying to update Resonite without forcing the platform type to be Windows seems to result in SteamCMD segfaulting and failing to update the headless.

This forces the platform type to be Windows, resulting in the headless updating as expected.

Fixes https://github.com/shadowpanther/resonite-headless/issues/13